### PR TITLE
Merging hotfix:EA7- Bug:- Accessing link.txt file if no link is found

### DIFF
--- a/Backend/Controllers/AI/aiapi.js
+++ b/Backend/Controllers/AI/aiapi.js
@@ -77,6 +77,7 @@ module.exports.ask = async (req, res) => {
 
     try {
       // links.map(async (link) => await fs.appendFile("links.txt"));
+      await fs.appendFile(`${domain}-link.txt`, ""); //create file first
       for (let i = 0; i < uniqueContactLinks.length; i++) {
         // await fs.appendFile("links.txt", "Contact Us links");
         try {


### PR DESCRIPTION
Just added a simple line to create link.txt file before reading it. Sometimes when no link was found, file was not getting crated which was triggering Error: EA7